### PR TITLE
fix panics, fix unused err

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -127,7 +127,9 @@ func (sys *System) FetchUserEvents(ctx context.Context, filter nostr.Filter) (ma
 			for {
 				select {
 				case evt := <-sub.Events:
-					results[evt.PubKey] = append(results[evt.PubKey], evt)
+					if evt != nil {
+						results[evt.PubKey] = append(results[evt.PubKey], evt)
+					}
 				case <-sub.EndOfStoredEvents:
 					return
 				}
@@ -142,12 +144,12 @@ func (sys *System) FetchUserEvents(ctx context.Context, filter nostr.Filter) (ma
 func ParseMetadata(event *nostr.Event) (meta ProfileMetadata, err error) {
 	if event.Kind != 0 {
 		err = fmt.Errorf("event %s is kind %d, not 0", event.ID, event.Kind)
-	} else if err := json.Unmarshal([]byte(event.Content), &meta); err != nil {
+	} else if er := json.Unmarshal([]byte(event.Content), &meta); er != nil {
 		cont := event.Content
 		if len(cont) > 100 {
 			cont = cont[0:99]
 		}
-		err = fmt.Errorf("failed to parse metadata (%s) from event %s: %w", cont, event.ID, err)
+		err = fmt.Errorf("failed to parse metadata (%s) from event %s: %w", cont, event.ID, er)
 	}
 
 	meta.PubKey = event.PubKey

--- a/outbox.go
+++ b/outbox.go
@@ -18,6 +18,7 @@ func (sys *System) ExpandQueriesByAuthorAndRelays(
 	}
 
 	relaysForPubkey := make(map[string][]*nostr.Relay, n)
+	mu := sync.Mutex{}
 
 	wg := sync.WaitGroup{}
 	wg.Add(n)
@@ -31,7 +32,9 @@ func (sys *System) ExpandQueriesByAuthorAndRelays(
 				if err != nil {
 					continue
 				}
+				mu.Lock()
 				relaysForPubkey[pubkey] = append(relaysForPubkey[pubkey], relay)
+				mu.Unlock()
 				c++
 				if c == 3 {
 					return


### PR DESCRIPTION
While testing my nostr client (too early to be public) that imports nostr-sdk occasional panics occur. These changes eliminate those panics at least. + this fixes unused err.

## SIGSEGV

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10 pc=0x10310749c]

goroutine 233 [running]:
github.com/nbd-wtf/nostr-sdk.(*System).FetchUserEvents.func1(0x0?, {{0x0, 0x0, 0x0}, {0x14000a04270, 0x1, 0x1}, {0x140003825b0, 0x7, 0x7}, ...})
	/Users/rs/Code/pkg/mod/github.com/nbd-wtf/nostr-sdk@v0.3.1/metadata.go:130 +0x16c
created by github.com/nbd-wtf/nostr-sdk.(*System).FetchUserEvents in goroutine 20
	/Users/rs/Code/pkg/mod/github.com/nbd-wtf/nostr-sdk@v0.3.1/metadata.go:120 +0x11c
```

## race condition

```
fatal error: concurrent map writes

goroutine 894 [running]:
github.com/nbd-wtf/nostr-sdk.(*System).ExpandQueriesByAuthorAndRelays.func1({0x14001788200, 0x40})
	/Users/rs/Code/src/github.com/nbd-wtf/nostr-sdk/outbox.go:34 +0xf8
created by github.com/nbd-wtf/nostr-sdk.(*System).ExpandQueriesByAuthorAndRelays in goroutine 837
	/Users/rs/Code/src/github.com/nbd-wtf/nostr-sdk/outbox.go:25 +0xc0
```
